### PR TITLE
Add type-driven generic data access to std

### DIFF
--- a/text/0000-dyno.md
+++ b/text/0000-dyno.md
@@ -1,0 +1,294 @@
+- Feature Name: `provide_any`
+- Start Date: 2021-11-04
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This RFC proposes adding a `provide_any` module to the core library. The module provides a generic API for objects to provide type-based access to data. (In contrast to the [`any` module](https://doc.rust-lang.org/nightly/std/any/index.html) which provides type-driven downcasting, the proposed module integrates downcasting into data access to provide a safer and more ergonomic API).
+
+By using the proposed API, a trait object can offer functionality like:
+
+```rust
+let s: String = object.request();
+let s = object.request_field::<str>(); // s: &str
+let x = object.request_field::<SpecificContext>(); // x: &SpecificContext
+```
+
+Here, the `request` and `request_field` methods are implemented by the author of `object` using `provide_any` as a framework.
+
+## Notes
+
+* A major motivation for this RFC is 'generic member access' for the `Error` trait. That was previously proposed in [RFC 2895](https://github.com/rust-lang/rfcs/pull/2895). This RFC will use `Error` as a driving example, but explicitly does not propose changes to `Error`.
+* A proof-of-concept implementation of this proposal (and the motivating extension to `Error`) is at [provide-any](https://github.com/nrc/provide-any).
+* `provide_any` is adapted from [dyno](https://github.com/mystor/dyno/tree/min_magic).
+
+
+# Motivation
+[motivation]: #motivation
+
+Trait objects (`Pointer<dyn Trait>`) provide strong abstraction over concrete types, often reducing a wide variety of types to just a few methods. This allows writing code which can operate over many types, using only a restricted interface. However, in practice some kind of partial abstraction is required, where objects are treated abstractly but can be queried for data only present in a subset of all types which implement the trait interface. In this case there are only bad options: speculatively downcasting to concrete types (inefficient, boilerplatey, and fragile due to breaking abstraction) or adding numerous methods to the trait which *might* be functionally implemented, typically returning an `Option` where `None` means not applicable for the concrete type (boilerplatey, confusing, and leads to poor abstractions).
+
+As a concrete example of the above scenario, consider the `Error` trait. It is often used as a trait objects so that all errors can be handled generically. However, classes of errors often have additional context that can be useful when handling or reporting errors. For example, an error [backtrace](https://doc.rust-lang.org/nightly/std/backtrace/struct.Backtrace.html), information about the runtime state of the program or environment, the location of the error in the source code, or help text suggestions. Adding backtrace methods to `Error` has already been implemented (currently unstable), but adding methods for all context information is impossible.
+
+Using the API proposed in this RFC, a solution might look something like:
+
+```rust
+use std::error::Error;
+
+// Some concrete error type.
+struct MyError {
+    backtrace: Backtrace,
+    suggestion: String,
+}
+
+impl Error for MyError {
+    fn provide_context<'a>(&'a self, mut req: Requisition<'a, '_>) {
+        req.provide_ref::<Backtrace>(&self.backtrace)
+            .provide_ref::<str>(&self.suggestion);
+    }
+}
+
+// Perhaps in a different crate or module, a function for handling all errors, not just MyError.
+fn report_error(e: &dyn Error) {
+    // Generic error handling.
+    // ...
+
+    // Backtrace.
+    if let Some(bt) = e.get_context_ref::<Backtrace>() {
+        emit_backtrace(bt);
+    }
+
+    // Help text suggestion.
+    // Note, we should use a newtype here to prevent confusing different string context information.
+    if let Some(suggestion) = e.get_context_ref::<str>() {
+        emit_suggestion(suggestion);
+    }
+}
+```
+
+An alternative is to do some kind of name-driven access, for example we could add a method `fn get(name: String) -> Option<&dyn Any>` to error (or use something more strongly typed than `String` to name data). The disadvantage of this approach is that the caller must downcast the returned object and that leads to opportunities for bugs since there is an implicit connection between the name and type of objects. If that connection changes, it will not be caught at compile time, only at runtime (and probably with a panicking unwrap, since programmers will be likely to unwrap the result of downcasting, believing it to be guaranteed by `get`). Furthermore, this approach is limited by constraints on `Any`, we cannot return objects by value, return objects which include references (due to the `'static` bound on `Any`), objects which are not object safe, or dynamically sized objects (e.g., we could not return an `&str`).
+
+Beyond `Error`, one could imagine using the proposed API in any situation where we might add arbitrary data to a generic object. Another concrete example might be the `Context` object passed to `future::poll`.
+
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+In this section I'll describe how the `provide_any` module is used and defined. Most of the module is not intended to be used directly. Typically there is an intermediate library which has a trait which extends `Provider` (we will use the `Error` trait in our examples) and has API which is a facade over `provide_any`'s API. `provide_any` is relatively complex in both interface and implementation. However, most users will not even be aware of its existence. Using `provide_any` in an intermediate library has some complexity, but using the intermediate library is straightforward for end users.
+
+`provide_any` supports generic, type-driven access to data and a mechanism for intermediate implementers to provide such data. The key parts of `provide_any`'s interface are the `Provider` trait for objects which can provide data, and the `request_by_type_tag` function for requesting data from an object which implements `Provider`. Note that end users should not call `request_by_type_tag` directly, it is a helper function for intermediate implementers to use.
+
+For the rest of this section we will explain the earlier example, starting from data access and work our way down the implementation to `provide_any`. Note that the fact that `Error` is in the standard library is immaterial to its use of `provide_any`. `provide_any` is a public module and can be used by any crate. We use `Error` as an example of how `provide_any` is used, we are not proposing changes to `Error` in this RFC.
+
+A user of `Error` trait objects can call `get_context_ref` to access data by type which might be carried by an `Error` object. The function returns an `Option` and will return `None` if the requested type of data is not carried. For example, to access a backtrace (in a world where the `Error::backtrace` method has been removed): `e.get_context_ref::<Backtrace>()` (specifying the type using the turbofish syntax may not be necessary if the type can be inferred from the context).
+
+Lets examine the changes to `Error` required to make this work:
+
+```rust
+pub mod error {
+    pub trait Error: Debug + Provider {
+        ...
+        fn provide_context<'a>(&'a self, _req: Requisition<'a, '_>) {}
+    }
+
+    impl<T: Error> Provider for T {
+        fn provide<'a>(&'a self, req: Requisition<'a, '_>) {
+            self.provide_context(req);
+        }
+    }
+
+    impl dyn Error {
+        ...
+        pub fn get_context_ref<T: ?Sized + 'static>(&self) -> Option<&T> {
+            crate::provide_any::request_by_type_tag::<'_, tags::Ref<T>>(self)
+        }
+    }
+}
+```
+
+`get_context_ref` is added as a method on `Error` trait objects (`Error` is also likely to support similar methods for values and possibly other types, but I will elide those details), it simply calls `provide_any::request_by_type_tag` (we'll discuss this function and the `tags::Ref` passed to it below). But where does the context data come from? If a concrete error type supports backtraces, then it must override the `provide_context` method when implementing `Error` (by default, the method does nothing, i.e., no data is provided, so `get_context_ref` will always returns `None`). `provide_context` is used in the blanket implementation of `Provider` for `Error` types, in other words `Provider::provide` is delegated to `Error::provide_context`.
+
+In `provide_context`, an error type provides access to data via a `Requisition` object, e.g., `req.provide_ref::<Backtrace>(&self.backtrace)`. The type of the reference passed to `provide_ref` is important here (and we encourage users to use explicit types with turbofish syntax even though it is not necessary). When a user calls `get_context_ref`, the requested type must match the type of an argument to `provide_ref`, e.g., the type of `&self.backtrace` is `&Backtrace`, so a call to `get_context_ref::<Backtrace>()` will return a reference to `self.backtrace`. An implementer can make multiple calls to `provide_ref` to provide multiple data with different types.
+
+Note that `Requisition` has methods for providing values as well as references, and for providing more complex types. These will be covered in the next section.
+
+The important parts of `provide_any` are
+
+```rust
+pub mod provide_any {
+    pub trait Provider {
+        fn provide<'a>(&'a self, req: Requisition<'a, '_>);
+    }
+
+    pub fn request_by_type_tag<'a, I: TypeTag<'a>>(provider: &'a dyn Provider) -> Option<I::Type> { ... }
+
+    pub struct Requisition<'a, 'b>(...);
+
+    impl<'a, 'b> Requisition<'a, 'b> {
+        pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self { ... }
+        ...
+    }
+
+    pub trait TypeTag<'a>: Sized + 'static {
+        type Type: 'a;
+    }
+
+    pub mod tags { ... }
+}
+```
+
+We have mostly covered how this interface is used above. The last piece is the concept of type tags, as used as a type parameter to `request_by_type_tag`.
+
+`core::any::TypeId` is a unique identifier for a type, but can only be used with types without lifetimes (or with only `'static` lifetimes). A type tag is an object which provides a layer of indirection to work around this limitation. For example, consider the type `&'l String`. It does not have a `TypeId` because of the `'l` lifetime. But we can use a type tag, `Ref<String>` to represent `&'l String` and `Ref<String>` does have a `TypeId`.
+
+The `TypeTag` trait is an abstraction over all type tags. It does not have any methods, only an associated type for the type which the tag represents. E.g., `<Ref<T> as TypeTag<'a>>::Type` is `&'a T`.
+
+There is no universal type tag. A concrete type tag must be written for a 'category' of types. A few common tags are provided in `provide_any::tags`, including `Value` for any type bounded by `'static`, and `Ref` for types of the form `&'a T` where `T: 'static`. For less common types, the user must provide a tag which implements `TypeTag`; in this way the `provide_any` API generalises to all types.
+
+Intermediate libraries (such as `error` in our examples) can choose to support only common type patterns so that the user is totally unaware of type tags, or a general API using type tags, or a hybrid approach where common cases are explicitly supported for ease of use and type tags are also supported for completeness.
+
+Note, that in the specialised variations, the user can use the type directly, e.g., `get_context_ref::<Backtrace>()`. But in the general case the user must provide the type tag, not the type itself, e.g., `get_by_tag::<tags::Ref<Backtrace>>()`. That prevents using type inference or type ascription for access, and the type tag must always be explicitly specified.
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+For details of the implementation, see the [provide-any](https://github.com/nrc/provide-any) repo which has a complete (though unpolished) implementation of this proposal, and an implementation of the extensions to `Error` used in the examples above.
+
+I propose that `provide_any` include the following type tags:
+
+```rust
+pub mod provide_any {
+    pub mod tags {
+        use super::TypeTag;
+        use core::marker::PhantomData;
+
+        /// Type-based `TypeTag` for `&'a T` types.
+        pub struct Ref<T: ?Sized + 'static>(PhantomData<T>);
+
+        impl<'a, T: ?Sized + 'static> TypeTag<'a> for Ref<T> {
+            type Type = &'a T;
+        }
+
+        /// Type-based `TypeTag` for `&'a mut T` types.
+        pub struct RefMut<T: ?Sized + 'static>(PhantomData<T>);
+
+        impl<'a, T: ?Sized + 'static> TypeTag<'a> for RefMut<T> {
+            type Type = &'a mut T;
+        }
+
+        /// Type-based `TypeTag` for static `T` types.
+        pub struct Value<T: 'static>(PhantomData<T>);
+
+        impl<'a, T: 'static> TypeTag<'a> for Value<T> {
+            type Type = T;
+        }
+
+        /// Tag combinator to wrap the given tag's value in an `Option<T>`
+        pub struct Optional<I>(PhantomData<I>);
+
+        impl<'a, I: TypeTag<'a>> TypeTag<'a> for Optional<I> {
+            type Type = Option<I::Type>;
+        }
+    }
+}
+```
+
+For intermediate libraries, `Value` serves the common case of providing a new or temporary value (for example, computing a `String` message from multiple fields), `Ref` and `RefMut` cover the common case of providing a reference to a field of the providing object (as in `Error::context_ref` providing a reference to `self.backtrace` in the motivating examples), where the field does not contain non-static references. `Optional` is used in the implementation of `provide_any`, it is public since it seems like it could be generally useful.
+
+### Requisition
+
+```rust
+impl<'a, 'b> Requisition<'a, 'b> {
+    /// Provide a value or other type with only static lifetimes.
+    pub fn provide_value<T, F>(&mut self, f: F) -> &mut Self
+    where
+        T: 'static,
+        F: FnOnce() -> T,
+    { ... }
+
+    /// Provide a reference, note that the referee type must be bounded by `'static`, but may be unsized.
+    pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self { ... }
+
+    /// Provide a value with the given `TypeTag`.
+    pub fn provide<I: TypeTag<'a>>(&mut self, value: I::Type) -> &mut Self { ... }
+
+    /// Provide a value with the given `TypeTag`, using a closure to prevent unnecessary work.
+    pub fn provide_with<I, F>(&mut self, f: F) -> &mut Self
+    where
+        I: TypeTag<'a>,
+        F: FnOnce() -> I::Type,
+    { ... }
+
+}
+
+```
+
+`Requisition` is an object for provider types to provide data to be accessed. It is required because there must be somewhere for the data (or a reference to it) to exist.
+
+`provide_value` and `provide_ref` are convenience methods for the common cases of providing a temporary value and providing a reference to a field of `self`, respectively. `provide_value` takes a function to avoid unnecessary work when querying for data of a different type; `provide_ref` does not use a function since creating a reference is typically cheap.
+
+`provide` and `provide_with` offer full generality, but require the explicit use of type tags.
+
+It seems reasonable that data might be accessed and provided on different threads. For this purpose, `provide_any` includes a version of `Requisition` which implements `Send`: `SendRequisition`. An open question is if it is also useful to support `Sync` variations (and if there is a better name).
+
+
+TODO docs from crate
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+There is some overlap in use cases with `Any`. It is sub-optimal for the standard library to include two modules with such similar functionality. However, I believe `provide_any` is more of a complement to `any`, rather than an alternative: `any` supports type-hiding where the concrete type is chosen by the library, whereas with `provide_any`, the library user chooses the concrete type.
+
+`provide_any` could be a stand-alone crate, however, a key motivation for `provide_any` is use in `Error` and that is only possible if `provide_any` is part of the standard library.
+
+`provide_any` is fairly complex, however, this is mitigated by restricting the exposed complexity to intermediate implementers or to users with advanced use cases. For many Rust programmers, they won't even know `provide_any` exists, but will reap the benefits via more powerful error handling, etc. 
+
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+There are are few ways to do without the proposed feature: in some situations it might be possible to add concrete accessor methods to traits. A trait could implement generic member access based on a value identifier (i.e., name-driven rather than type driven), such a method would return a `dyn Any` trait object. Or a user could speculatively downcast a trait object to access its data.
+
+Each of these approaches has significant downsides: adding methods to traits leads to a confusing API and is impractical in many situations (including for `Error`). Value-driven access only works with types which implement `Any`, that excludes types with lifetimes and unsized types; furthermore it requires the caller to downcast the result which is error-prone and fragile. Speculative downcasting violates the encapsulation of trait objects and is only possible if all implementers are known (again, not possible with `Error`).
+
+`provide_any` could live in its own crate, rather than in libcore. However, this would not be useful for `Error`.
+
+`provide_any` could be a module inside `any` rather than a sibling (it could then be renamed to `provide` or `provider`).
+
+There are numerous ways to tweak the API of a module like `provide_any`. The dyno and object-provider crates provide two such examples. There are many others, for example providing more patterns of types without requiring tags, not providing any common type patterns (i.e., always requiring tags), not exposing tags at all, etc.
+
+One hazard that must be avoided with such tweaks is that the API must distinguish between reference types with a `'static` lifetime and value types (with no lifetimes), either by using type tags or by having separate mechanisms for handling references and values. If this is done improperly, the API could be unsound. As an example, consider an API which lets an object provide a reference with type `&'a str` (where `'a` is the lifetime of some local scope), then a caller requests an object of type `&'static str` using an API designed for values (possible because that type satisfies the `'static` bound). Without some care, it is possible for the two types to be confused (because the lifetime is not reflected in the type tag or `TypeId`) and for the `&'a str` to be returned with the wrong lifetime. I believe this is not possible in the current proposal, but was possible in an earlier, more ergonomic iteration.
+
+A slightly different approach is to remove the convenience methods and always require the use of type tags. I believe this is sub-optimal since it requires users to learn a new concept (type tags) and makes using the methods less ergonomic. However, it does have advantages: code is less prone to silent inference errors since the type tag must always be explicitly specified, and the API is smaller.
+
+# Prior art
+[prior-art]: #prior-art
+
+
+Operations involving runtime types are intrinsically tied to the specifics of a language, its runtime, and type system. Therefore, there is not much prior art from other languages.
+
+A closely related feature from other languages is reflection. However, reflective field access is usually name-driven rather than type-driven. Due to Rust's architecture, general reflection is impossible.
+
+In Rust, there are several approaches to the problem. This proposal is adapted from [dyno](https://github.com/mystor/dyno/); [object provider](https://github.com/mystor/object-provider/) is a similar crate from the same author.
+
+Some Rust error libraries provide roughly similar functionality. For example, [Anyhow](https://github.com/dtolnay/anyhow) (and [Eyre](https://github.com/yaahc/eyre)) allow adding context to errors in `Result`s, which can be accessed by downcasting the error object to the context object.
+
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+Can we improve on the proposed API? Although we have iterated on the design extensively, there might be room for improvement either by general simplification, or making the most general cases using type tags more ergonomic.
+
+As with any relatively abstract library, naming the concepts in `provide_any` is difficult. Are there better names? In particular, 'tag' and 'requisition' are very generic terms which could indicate their purpose better.
+
+Extending the API of `Error` is a primary motivation for this RFC, but those extensions are only sketched in the examples and implementation. What exactly should `Error`'s API look like?
+
+It was suggested by @Plecra in the [comments](https://github.com/rust-lang/rfcs/pull/2895#issuecomment-735713486) of RFC 2895, that this mechanism could be used for providing data from a future's `Context` object. That is a more demanding application since it is likely to require `&mut` references, objects with complex lifetimes, and possibly even closures to be returned. That has motivated seeking a general API for `provide_any`, rather than only supporting `'static` lifetimes.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+A possible extension to this work is full downcasting using type tags - a proper alternative to `Any`. Such downcasting is available in dyno and is an implementation detail of the proof of concept implementation for this RFC. It is not part of `provide_any`'s interface in order to minimise the proposal and avoid overlap with `Any`, however, I don't see any technical issues with exposing such functionality in the future if there is demand.


### PR DESCRIPTION
This RFC proposes adding a `provide_any` module to the core library. The module provides a generic API for objects to provide type-based access to data. (Whereas the [`any` module](https://doc.rust-lang.org/nightly/std/any/index.html) provides type-driven downcasting, the proposed module integrates the downcasting into data access to provide a safer and more ergonomic API).

By using the proposed API, an object can have functionality like:

```rust
let s: String = object.request();
let s = object.request_field::<str>(); // s: &str
let x = object.request_field::<SpecificContext>(); // x: &SpecificContext
```
